### PR TITLE
Allow for precision=0 in number bindingHandler

### DIFF
--- a/javascripts/knockout/bindings/number-formatting.js
+++ b/javascripts/knockout/bindings/number-formatting.js
@@ -15,7 +15,7 @@ ko.bindingHandlers.number = {
 
         value = parseFloat(value) || 0;
 
-        if (precision > 0)
+        if (precision >= 0)
             value = value.toFixed(precision)
 
             numarray = value.toString().split('.');

--- a/javascripts/knockout/bindings/number-formatting.js
+++ b/javascripts/knockout/bindings/number-formatting.js
@@ -9,7 +9,7 @@ ko.bindingHandlers.number = {
 
 		var	separator = unwrap(aba().separator) || defaults.separator,
 			decimal = unwrap(aba().decimal) || defaults.decimal,
-			precision = unwrap(aba().precision) || defaults.precision,
+			precision = unwrap(aba().precision) === 0 ? 0 : (unwrap(aba().precision) || defaults.precision),
 			symbol = unwrap(aba().symbol) || defaults.symbol,
 			after = unwrap(aba().after) || defaults.after;
 
@@ -35,7 +35,7 @@ ko.bindingHandlers.number = {
 	defaults: {
 		separator: ',',
 		decimal: '.',
-		precision: 0,
+		precision: -1,
 		symbol: '',
 		after: false
 	}


### PR DESCRIPTION
I changed this, so precision 0 will display a number without decimals. If you need infinite precision now, you need to set to e.g. -1 instead of 0